### PR TITLE
Remove opacity on footer

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,6 +1,5 @@
 .footer {
   background: black;
-  opacity: 0.8;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
Small fix to the footer to remove the opacity.

<img width="647" alt="Screenshot 2020-12-02 at 10 13 29" src="https://user-images.githubusercontent.com/16326211/100859392-160b4a00-3487-11eb-918b-1d7245495690.png">


Closes #153 